### PR TITLE
Bump runtime to 42

### DIFF
--- a/org.gnome.design.VectorSlicer.json
+++ b/org.gnome.design.VectorSlicer.json
@@ -1,7 +1,7 @@
 {
   "app-id" : "org.gnome.design.VectorSlicer",
   "runtime" : "org.gnome.Platform",
-  "runtime-version" : "40",
+  "runtime-version" : "42",
   "sdk" : "org.gnome.Sdk",
   "sdk-extensions" : [
     "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
Any idea how to resolve this?

```
error: failed to get `librsvg` as a dependency of package `vector-slicer v0.1.0 (/run/build/vector-slicer)`
Caused by:
  failed to load source for dependency `librsvg`
Caused by:
  Unable to update https://gitlab.gnome.org/gnome/librsvg#528a84f9
Caused by:
  can't checkout from 'https://gitlab.gnome.org/gnome/librsvg': you are in the offline mode (--offline)
FAILED: src/vector-slicer 
```

It seems there is a git dependency of librsvg in two places but flatpak-builder doesn't allow to access the network. Do I switch it to using a release?

Ok I thought the module name was wrong in `CARGO_HOME` but doesn't work when setting it to `"CARGO_HOME" : "/run/build/vector-slicer/cargo"`